### PR TITLE
Add initial dummy CI

### DIFF
--- a/.github/actions/Dockerfile
+++ b/.github/actions/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:latest
+
+LABEL "com.github.actions.name" = "CI Setup"
+LABEL "com.github.actions.description" = "Sets up the environment to run the CI"
+LABEL "com.github.actions.icon" = "chevron-right"
+LABEL "com.github.actions.color" = "green"
+
+LABEL "repository" = "https://github.com/antonpaa/hello-github-actions"
+LABEL "homepage" = "https://github.com/antonpaa/hello-github-actions"
+
+ADD entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -1,0 +1,17 @@
+name: "Default actions"
+description: "Output project name"
+author: "antonpaa@github.com"
+
+inputs:
+  PROJECT_NAME:
+    description: "Name of the project"
+    required: true
+    default: "none"
+
+runs:
+  using: "docker"
+  image: "Dockerfile"
+
+branding:
+  icon: "code"
+  color: "blue"

--- a/.github/actions/entrypoint.sh
+++ b/.github/actions/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -l
+
+sh -c "echo Project $INPUT_PROJECT_NAME: CI executed"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+# This workflow acts as a placeholder for the CI actions to be implemented
+
+name: Default CI
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: CI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: ./.github/actions
+        with:
+          PROJECT_NAME: "TBA"


### PR DESCRIPTION
Adds the CI actions when pushes are done for `master` or a PR against `master` is created. The actions currently have no functionality - they just execute `echo` level actions.